### PR TITLE
update workflow to not mark PRs as stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,27 +1,25 @@
-name: Stale issues and pull requests
+name: Stale issues
 
 on:
+  workflow_dispatch:
   schedule:
   - cron: "21 4 * * *"
 
 jobs:
   stale:
     permissions:
+      actions: write
       issues: write
-      pull-requests: write
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/stale@v10
       with:
-        stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. This issue will be closed in 30 days unless new comments are made or the stale label is removed.'
-        stale-pr-message: 'This PR is stale because it has been open 90 days with no activity. This PR will be closed in 30 days unless new comments are made or the stale label is removed.'
+        stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. This issue will be closed in 30 days unless new comments are made or the stale label is removed. To skip these checks, apply the "lifecycle/frozen" label.'
         stale-issue-label: 'lifecycle/stale'
-        stale-pr-label: 'lifecycle/stale'
+        exempt-issue-labels: 'lifecycle/frozen,feature,enhancement'
         days-before-stale: 90
         close-issue-message: 'This issue was automatically closed due to inactivity.'
-        close-pr-message: 'This pull request was automatically closed due to inactivity.' 
         days-before-issue-close: 30
-        days-before-pr-close: 30
         remove-stale-when-updated: true
         operations-per-run: 300


### PR DESCRIPTION
This PR removes the ability to mark PRs as stale and auto-close them. Only issues are marked as stale and auto-closed.
It also fixes the permissions so that stale cache can be deleted. See https://github.com/actions/stale/pull/1248