### PR TITLE
Add OCI standard image labels

### DIFF
--- a/deployments/container/Dockerfile.distroless
+++ b/deployments/container/Dockerfile.distroless
@@ -57,6 +57,7 @@ RUN ["/bin/rm", "-rf", "/usr/local/lib/python3.13/site-packages/urllib3-2.3.0.di
 
 ARG VERSION="N/A"
 ARG GIT_COMMIT="unknown"
+ARG BUILD_TIMESTAMP
 
 LABEL io.k8s.display-name="NVIDIA CC Manager"
 LABEL name="NVIDIA CC Manager"
@@ -66,5 +67,14 @@ LABEL com.nvidia.git-commit=${GIT_COMMIT}
 LABEL release="N/A"
 LABEL summary="NVIDIA Confidential Compute Manager for Kubernetes"
 LABEL description="See summary"
+LABEL org.opencontainers.image.base.name="nvcr.io/nvidia/distroless/python"
+LABEL org.opencontainers.image.created="${BUILD_TIMESTAMP}"
+LABEL org.opencontainers.image.documentation="https://docs.nvidia.com/datacenter/cloud-native/gpu-operator"
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/k8s-cc-manager.git"
+LABEL org.opencontainers.image.title="NVIDIA CC Manager"
+LABEL org.opencontainers.image.url="https://catalog.ngc.nvidia.com/orgs/nvidia/cloud-native/containers/k8s-cc-manager"
+LABEL org.opencontainers.image.vendor="NVIDIA"
+LABEL org.opencontainers.image.version="${VERSION}"
 
 ENTRYPOINT ["python3", "/app/main.py"]

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -83,6 +83,8 @@ $(BUILD_TARGETS): build-%:
 			--build-arg BASE_DIST="$(DIST)" \
 			--build-arg CUDA_VERSION="$(CUDA_VERSION)" \
 			--build-arg VERSION="$(VERSION)" \
+			--build-arg GIT_COMMIT="$(GIT_COMMIT)" \
+			--build-arg BUILD_TIMESTAMP="$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")" \
 			--build-arg CVE_UPDATES="$(CVE_UPDATES)" \
 			--build-arg GPU_ADMIN_TOOLS_VERSION="$(GPU_ADMIN_TOOLS_VERSION)" \
 			--build-arg RUNTIME_VERSION="$(RUNTIME_VERSION)" \

--- a/versions.mk
+++ b/versions.mk
@@ -14,9 +14,9 @@
 
 VERSION ?= v1.0.0
 
-vVERSION := v$(VERSION:v%=%)
-
 CUDA_VERSION := 12.4.0
 
 GPU_ADMIN_TOOLS_VERSION := v2026.06.05
 RUNTIME_VERSION := 3.13-v4.0.9
+
+GIT_COMMIT ?= $(shell git describe --match="" --dirty --long --always --abbrev=40 2> /dev/null || echo "")


### PR DESCRIPTION
This PR adds well-known OCI Image labels to the k8s-cc-manager image metadata.

**Before**
```
$ docker inspect --format='{{json .Config.Labels}}' nvcr.io/nvidia/cloud-native/k8s-cc-manager:v0.4.2 | jq
{
  "com.nvidia.git-commit": "unknown",
  "description": "See summary",
  "io.k8s.display-name": "NVIDIA CC Manager",
  "name": "NVIDIA CC Manager",
  "org.opencontainers.image.created": "2026-06-11T18:01:15Z",
  "org.opencontainers.image.documentation": "https://developer.download.nvidia.com/distroless-oss/docs.html",
  "org.opencontainers.image.revision": "d5891068bf92407b17825c29f462da9643457b04",
  "org.opencontainers.image.title": "Python 3.13 Distroless Image",
  "org.opencontainers.image.url": "https://developer.download.nvidia.com/distroless-oss/index.html",
  "org.opencontainers.image.version": "v4.0.8",
  "release": "N/A",
  "summary": "NVIDIA Confidential Compute Manager for Kubernetes",
  "vendor": "NVIDIA",
  "version": "f8297486"
}
```

**After**
```
$ docker inspect --format='{{json .Config.Labels}}' ghcr.io/nvidia/k8s-cc-manager:9740309b-distroless | jq
{
  "com.nvidia.git-commit": "9740309b2a0f568baba1f2bbedefb7c77954ef28",
  "description": "See summary",
  "io.k8s.display-name": "NVIDIA CC Manager",
  "name": "NVIDIA CC Manager",
  "org.opencontainers.image.base.name": "nvcr.io/nvidia/distroless/python",
  "org.opencontainers.image.created": "2026-08-13T21:12:05Z",
  "org.opencontainers.image.documentation": "https://docs.nvidia.com/datacenter/cloud-native/gpu-operator",
  "org.opencontainers.image.revision": "9740309b2a0f568baba1f2bbedefb7c77954ef28",
  "org.opencontainers.image.source": "https://github.com/NVIDIA/k8s-cc-manager.git",
  "org.opencontainers.image.title": "NVIDIA CC Manager",
  "org.opencontainers.image.url": "https://catalog.ngc.nvidia.com/orgs/nvidia/cloud-native/containers/k8s-cc-manager",
  "org.opencontainers.image.vendor": "NVIDIA",
  "org.opencontainers.image.version": "9740309b",
  "release": "N/A",
  "summary": "NVIDIA Confidential Compute Manager for Kubernetes",
  "vendor": "NVIDIA",
  "version": "9740309b"
}
```
