### PR TITLE
bump python distroless image to v3.14-4.1.1

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -54,7 +54,7 @@ third-party dependency and is not listed here.
 | `requests` | 2.34.2 | Apache-2.0 | https://github.com/psf/requests |
 | `requests-oauthlib` | 2.0.0 | ISC | https://github.com/requests/requests-oauthlib |
 | `six` | 1.17.0 | MIT | https://github.com/benjaminp/six |
-| `urllib3` | 2.6.3 | MIT | https://urllib3.readthedocs.io |
+| `urllib3` | 2.7.0 | MIT | https://urllib3.readthedocs.io |
 | `websocket-client` | 1.9.0 | Apache-2.0 | https://github.com/websocket-client/websocket-client.git |
 | `yarl` | 1.24.5 | Apache-2.0 | https://github.com/aio-libs/yarl |
 
@@ -2024,7 +2024,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ### urllib3
 
-* Version: 2.6.3
+* Version: 2.7.0
 * License: MIT
 * Source: https://urllib3.readthedocs.io
 

--- a/deployments/container/Dockerfile.distroless
+++ b/deployments/container/Dockerfile.distroless
@@ -1,8 +1,8 @@
 # Multi-stage build for NVIDIA k8s-cc-manager Python implementation
-ARG RUNTIME_VERSION="3.13-v4.0.2"
+ARG RUNTIME_VERSION="3.14-v4.1.1"
 
 # Stage 1: Build dependencies
-FROM python:3.13-slim AS builder
+FROM python:3.14-slim AS builder
 
 WORKDIR /build
 
@@ -17,7 +17,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir --prefix=/build/deps -r requirements.txt
 # upgrade urllib3 to address CVE.
 # Also see https://github.com/kubernetes-client/python/issues/2477#issuecomment-3628140179
-RUN pip install --upgrade --no-cache-dir --no-warn-conflicts --prefix=/build/deps urllib3==2.6.3
+RUN pip install --upgrade --no-cache-dir --no-warn-conflicts --prefix=/build/deps urllib3==2.7.0
 
 RUN git clone --branch ${GPU_ADMIN_TOOLS_VERSION} https://github.com/NVIDIA/gpu-admin-tools.git
 
@@ -48,12 +48,12 @@ COPY --from=stg2 /build/rm /bin/rm
 WORKDIR /app
 
 # Set PYTHONPATH to find installed packages
-ENV PYTHONPATH=/usr/local/lib/python3.13/site-packages
+ENV PYTHONPATH=/usr/local/lib/python3.14/site-packages
 
 # Run as non-root (distroless default)
 USER 0:0
 # clean up left over dist-info
-RUN ["/bin/rm", "-rf", "/usr/local/lib/python3.13/site-packages/urllib3-2.3.0.dist-info"]
+RUN ["/bin/rm", "-rf", "/usr/local/lib/python3.13/site-packages/urllib3-2.6.3.dist-info"]
 
 ARG VERSION="N/A"
 ARG GIT_COMMIT="unknown"

--- a/deployments/container/Dockerfile.ubi8
+++ b/deployments/container/Dockerfile.ubi8
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ARG GPU_ADMIN_TOOLS_VERSION="v2025.10.20"
 COPY requirements.txt .
 RUN pip install --no-cache-dir --prefix=/build/deps -r requirements.txt
-RUN pip install --upgrade --no-cache-dir --no-warn-conflicts --prefix=/build/deps urllib3==2.6.3
+RUN pip install --upgrade --no-cache-dir --no-warn-conflicts --prefix=/build/deps urllib3==2.7.0
 
 RUN git clone --branch ${GPU_ADMIN_TOOLS_VERSION} https://github.com/NVIDIA/gpu-admin-tools.git
 
@@ -55,7 +55,7 @@ RUN if [ -n "${CVE_UPDATES}" ]; then \
         rm -rf /var/cache/yum/*; \
     fi
 
-RUN rm -rf /usr/local/lib/python3.9/site-packages/urllib3-2.3.0.dist-info || true
+RUN rm -rf /usr/local/lib/python3.9/site-packages/urllib3-2.7.0.dist-info || true
 
 ARG VERSION="N/A"
 ARG GIT_COMMIT="unknown"

--- a/versions.mk
+++ b/versions.mk
@@ -17,6 +17,6 @@ VERSION ?= v1.0.0
 CUDA_VERSION := 12.4.0
 
 GPU_ADMIN_TOOLS_VERSION := v2026.06.05
-RUNTIME_VERSION := 3.13-v4.0.9
+RUNTIME_VERSION := 3.14-v4.1.1
 
 GIT_COMMIT ?= $(shell git describe --match="" --dirty --long --always --abbrev=40 2> /dev/null || echo "")


### PR DESCRIPTION
This PR bumps the base image to the latest available distroless image for python 3.14

It also addresses the two new HIGH CVEs flagged for the `urllib3` dependency

- https://github.com/urllib3/urllib3/security/advisories/GHSA-mf9v-mfxr-j63j
- https://github.com/urllib3/urllib3/security/advisories/GHSA-qccp-gfcp-xxvc